### PR TITLE
Add `install` rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,14 @@ all: macvdmtool
 
 macvdmtool: $(OBJS)
 	cc -o $@ $(OBJS) $(LDFLAGS)
+
+ifeq ($(PREFIX),)
+    PREFIX := /usr/local
+endif
+
+INSTALL := /usr/bin/install
+
+.PHONY: install
+install: macvdmtool
+	@sudo $(INSTALL) -d "$(PREFIX)/bin/"
+	@sudo $(INSTALL) -m 755 -o root -g wheel "${<}" "$(PREFIX)/bin/"

--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ INSTALL := /usr/bin/install
 .PHONY: install
 install: macvdmtool
 	@sudo $(INSTALL) -d "$(PREFIX)/bin/"
-	@sudo $(INSTALL) -m 755 -o root -g wheel "${<}" "$(PREFIX)/bin/"
+	@sudo $(INSTALL) -m 755 -o root -g wheel "$(<)" "$(PREFIX)/bin/"


### PR DESCRIPTION
Allows for `make install` to compile and install to `$(PREFIX)/bin` which is `/usr/local/bin` by default